### PR TITLE
pysoundfile dependency

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - numba==0.51.*
     - pandas==1.0.*
     - pretty_midi==0.2.*
-    - pysoundfile==0.9.*
+    - soundfile==0.9.*
     - scipy==1.3.*
     - numpy==1.17.*
     # - libfmp  # using a freshly downloaded version of libfmp in the ci script

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
                       'numpy >= 1.17.0, < 2.0.0',
                       'pandas >= 1.0.0, < 2.0.0',
                       'pretty_midi >= 0.2.0, < 1.0.0',
-                      'pysoundfile >= 0.9.0, < 1.0.0',
+                      'soundfile >= 0.9.0, < 1.0.0',
                       'scipy >= 1.3.0, < 2.0.0'],
     python_requires='>=3.6',
     extras_require={


### PR DESCRIPTION
This package depends on the old naming of pysoundfile, the package was renamed at version 0.8 to just soundfile. Having the old package name as a dependency for this repo means that when other packages have the newer name both are installed, this can cause problems as both packages are imported using import soundfile.

I suggest changing the dependency to soundfile rather than pysoundfile, there is no need to adjust versions as 0.8.x and 0.9.x are available on pypi for both pysoundfile and soundfile, though pysoundfile seems to be no longer available for 0.10.x and above.

I ran the tests, with no problem and also tested the save_audio function which worked fine.