### PR TITLE
Update project dependencies to work with python>=3.10  <=3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The libfmp package bundles core concepts from the music information retrieval (M
 
 ## Installing
 
-With Python >= 3.6, you can install libfmp using the Python package manager pip:
+With Python >= 3.10, you can install libfmp using the Python package manager pip:
 
 ```
 pip install libfmp

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,19 +1,19 @@
 name: libfmp_docs
 
 dependencies:
-  - python==3.8.*
+  - python==3.10.*
   - pip
   - pip:
-    - ipython==7.8.*
-    - librosa==0.8.*
+    - ipython==8.38.*
+    - librosa==0.10.*
     - matplotlib==3.3.*
-    - music21==5.7.*
-    - numba==0.56.*
-    - pandas==1.1.*
+    - music21==9.9.*
+    - numba==0.59.*
+    - pandas==2.3.*
     - pretty_midi==0.2.*
     - soundfile==0.9.*
     - scipy==1.5.*
-    - numpy==1.19.*
+    - numpy==1.26.*
     # - libfmp  # using a freshly downloaded version of libfmp in the ci script
-    - sphinx==4.0.*
-    - sphinx_rtd_theme==0.5.*
+    - sphinx==7.4.*
+    - sphinx_rtd_theme==2.0.*

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,16 +4,16 @@ dependencies:
   - python==3.10.*
   - pip
   - pip:
-    - ipython==8.38.*
-    - librosa==0.10.*
-    - matplotlib==3.3.*
-    - music21==9.9.*
-    - numba==0.59.*
-    - pandas==2.3.*
-    - pretty_midi==0.2.*
-    - soundfile==0.9.*
-    - scipy==1.5.*
-    - numpy==1.26.*
+    - ipython>=8.10.0,<9.0.0
+    - librosa>=0.10.0,<1.0.0
+    - matplotlib>=3.3.0,<4.0.0
+    - music21>=9.1.0,<10.0.0
+    - numba>=0.58.1,<1.0.0
+    - numpy>=1.19.0,<3.0.0
+    - pandas>=1.1.0,<3.0.0
+    - pretty_midi>=0.2.0,<1.0.0
+    - soundfile>=0.9.0,<1.0.0
+    - scipy>=1.5.0,<2.0.0
     # - libfmp  # using a freshly downloaded version of libfmp in the ci script
     - sphinx==7.4.*
     - sphinx_rtd_theme==2.0.*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,7 +113,7 @@ autodoc_preserve_defaults = True
 # Interpret "Returns" section as "Args" section
 napoleon_custom_sections = [('Returns', 'params_style'), ('Attributes', 'params_style')]
 
-extlinks = {'fmpbook': ('https://www.audiolabs-erlangen.de/fau/professor/mueller/bookFMP', 'FMP'),
+extlinks = {'fmpbook': ('https://www.audiolabs-erlangen.de/fau/professor/mueller/bookFMP%s', 'FMP%s'),
             'fmpnotebook': ('https://www.audiolabs-erlangen.de/resources/MIR/FMP/%s.html', '%s.ipynb')}
 
 

--- a/libfmp/c1/c1s2_symbolic_rep.py
+++ b/libfmp/c1/c1s2_symbolic_rep.py
@@ -14,6 +14,12 @@ import music21 as m21
 import libfmp.b
 
 
+def _get_part_instrument_name(part):
+    """Return a stable instrument label across music21 versions."""
+    instrument = part.getInstrument(returnDefault=True)
+    return instrument.partName or instrument.instrumentName or instrument.bestName() or 'Unknown'
+
+
 def csv_to_list(csv):
     """Convert a csv score file to a list of note events
 
@@ -95,9 +101,9 @@ def xml_to_list(xml):
     score = []
 
     for part in xml_data.parts:
-        instrument = part.getInstrument().instrumentName
+        instrument = _get_part_instrument_name(part)
 
-        for note in part.flat.notes:
+        for note in part.flatten().notes:
 
             if note.isChord:
                 start = note.offset

--- a/setup.py
+++ b/setup.py
@@ -24,18 +24,18 @@ setup(
     ],
     keywords='audio music sound',
     license='MIT',
-    install_requires=['ipython >= 7.10.0, < 8.0.0',
-                      'librosa >= 0.8.0, < 1.0.0',
+    install_requires=['ipython >= 8.10.0, < 9.0.0',
+                      'librosa >= 0.10.0, < 1.0.0',
                       'matplotlib >= 3.3.0, < 4.0.0',
-                      'music21 >= 5.7.0, <= 9.3.0',
-                      'numba >= 0.56.0, < 1.0.0',
+                      'music21 >= 9.1.0, < 10.0.0',
+                      'numba >= 0.58.1, < 1.0.0',
                       'numpy >= 1.19.0, < 3.0.0',
                       'pandas >= 1.1.0, < 3.0.0',
                       'pretty_midi >= 0.2.0, < 1.0.0',
                       'soundfile >= 0.9.0, < 1.0.0',
                       'scipy >= 1.5.0, < 2.0.0'],
-    python_requires='>=3.8',
+    python_requires='>=3.10',
     extras_require={
-        'tests': ['pytest == 6.2.*']
+        'tests': ['pytest >= 8.0.0, < 9.0.0']
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as fdesc:
 
 setup(
     name='libfmp',
-    version='1.2.6',
+    version='1.2.7',
     description='Python module for fundamentals of music processing',
     author='Meinard Müller and Frank Zalkow',
     author_email='meinard.mueller@audiolabs-erlangen.de',


### PR DESCRIPTION
This pull request updates the project's Python and library dependencies to support newer versions and ensures compatibility with the latest `music21` releases.

Python versions <= 3.10 have reached End of Life (EOL) (e.g. Python 3.9 reached EOL in Oct 25), so we bump it to >=3.10.
Also, an update of other dependencies, especially music21, allows for easier use of this library in other libraries such as synctoolbox (https://github.com/meinardmueller/synctoolbox). 